### PR TITLE
Override elasticsearch location with env

### DIFF
--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -1,11 +1,14 @@
 require "yaml"
 require "elasticsearch/search_server"
+require "dotenv"
+
+Dotenv.load
 
 class SearchConfig
 
   def search_server
     Elasticsearch::SearchServer.new(
-      elasticsearch["base_uri"],
+      ENV['QUIRKAFLEEG_ELASTICSEARCH_LOCATION'] || elasticsearch["base_uri"],
       elasticsearch_schema,
       index_names
     )


### PR DESCRIPTION
To minimise manual Cheffing, we're putting the elasticsearch node location config in an env var.
