### PR TITLE
Change enable queue variable to match our needs

### DIFF
--- a/config/initializers/async.rb
+++ b/config/initializers/async.rb
@@ -1,3 +1,3 @@
 # This file can be overwritten on deployment
 
-set :enable_queue, ! ENV["ENABLE_QUEUE"].nil?
+set :enable_queue, ! ENV["QUIRKAFLEEG_RUMMAGER_ENABLE_QUEUE"].nil?


### PR DESCRIPTION
So, at the moment, we're not posting stuff to Elasticsearch asynchronously, so we're getting index locked errors. I'm not sure if this will fix things, but it will stop the errors in the backend, and we should be doing it this way anyway.
